### PR TITLE
Removed STATIC_ROOT from settings preventing runserver command.

### DIFF
--- a/newspaper_project/settings.py
+++ b/newspaper_project/settings.py
@@ -122,7 +122,6 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
-STATIC_ROOT = os.path.join(BASE_DIR, 'templates')
 STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'users.CustomUser'


### PR DESCRIPTION
Running project failed with the warning,

django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
?: (staticfiles.E002) The STATICFILES_DIRS setting should not contain the STATIC_ROOT setting.

Removed "STATIC_ROOT" from settings preventing runserver command from running.